### PR TITLE
markdown formatting and spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,51 @@
-# customer_churn_project
+# Customer Churn Project
 
-We selected the Customer churn project as our Modlue 3 team project for two main reasons:
+We selected the customer churn project as our Module 3 team project for two main reasons:
 1. This is a business problem that would apply to other workplaces, or as an example for the job interviews. 
 2. The data is pretty clean and does not need too much preprocessing work, so that we can focus on the modeling. 
 
 The data is downloaded from kaggle: https://www.kaggle.com/becksddf/churn-in-telecoms-dataset/kernels
 
-Business Questions:
+## Business Questions:
 
-    1. Build a classifier to predict whether a customer will ("soon") stop doing business with SyriaTel, a telecommunications 
-    company.
-    2. Most naturally, your audience here would be the telecom business itself, interested in losing money on customers who don't 
-    stick around very long. Are there any predictable patterns here?
+1. Build a classifier to predict whether a customer will ("soon")stop doing business with SyriaTel, a telecommunications company.
+2. Most naturally, your audience here would be the telecom business itself, interested in losing money on customers who don't stick around very long. Are there any predictable patterns here?
 
-Project goal: 
+## Project goal:
 
-    Successfully predict customers who will stop doing business with SyriaTel, so that the company would not lose 
-    money on these customers.
+> Successfully predict customers who will stop doing business with SyriaTel, so that the company would not lose money on these customers.
 
-Process: 
+## Process:
 
-    1. Preprocessing data: 
-        a. Use HotOneEncoder dummy-coded the 'state' varible.
-        b. Coded 'international plan', 'voice mail plan' into '1' and '0' from string. 
-        3. Define features X, and target y. 
-        4. Split X_train y_train into subsets: X_train1, X_test1, y_train1, y_test1. 
-        5. Scaled X_train1, X_test1 Using  StandardScaler 
-        6. The target data is inbalanced, True 15%; False 85%. 
-        7. Create a new feature of 'total charge' that is the sum of all the charges. 
-    
-    2. Modeling: 
-        a. We selected StakingClassifier as our algorithm. 
-                Model stacking is also called meta-stacking, where multiple models are stacked, and their predictions are aggregated. In this case, 
-                more models are better because the more likely they have the potential to pick up different characteristics of the data.
-        b. We created two functions: 
-            metircs: it is a funciton to generate accuracy, precision, recall, and f-1 scores. 
-            model: it is a funciton that generate the results from StackingClassifier with four parameters: X_train, X_test, y_train, y_test. 
-            Estimators (submodels) selection: We selected K-Nearest-Neighbors(KNN), RandomForest, LogisticRegression, and GradientBoosting as submodels first, 
-            but the results showed that KNN generates had very poor performance on prediction with low scores on accurcy, precision, recall, and f-1. Therefore,
-            we removed KNN from the estimators of the StackingClassifier algorithm. We used logistic Regression model as the final model which is the default as well.
-        c. Model results: we got reletively good model performance using Stacking. 
-        d. Model improvement: 
-            The specific goal is to imporve the model performance of correctly predicting a customer will stop doing business, which is the TRUE 
-            value in the target data. More specifically, we want our model predicts correctly when it is true, and reduce false negative, which means 
-            it is predicted false while it is actually true. 
-            Therefore, we want a high recall score. Our initial recall score is around 0.75. 
-        d. feature selections/engineering: In order to increase the recall score, we tried to remove some features that have small values on feature importances. When removing
-        dummyed 'state' variable, the recall score increases. Removing the other features resulted in decreasing the recall scores. Therefore, we keeps all features but 'state'.
-        
-     3. Model evaluation: We generated the confusion matrix and applies the function named 'metrics' to generate accruacy, precision, recall, and f-1 scores. 
-          Final model: StackingClassifier with estimators = [('rf', RandomForestClassifier()),('log', LogisticRegression(solver = 'liblinear')), ('grad',       
-                                                              GradientBoostingClassifier())] , 
-                                          final_estimator = 'LogisticRegression()',
-                                                       cv = 5
-          Model evaluation: Accuracy: 0.98; Precision: 1.0;  Recall: 0.89;  F1: 0.94
- 
- Pickle: 
- 
-     we create a pickle file named model.pickle. Use pickle, we can call the model. 
-     
- 
-
-
-
+1. Preprocessing data:
+    - Use HotOneEncoder dummy-coded the 'state' variable.
+    - Coded 'international plan', 'voice mail plan' into '1' and '0' from string.
+    - Define features X, and target y.
+    - Split X_train y_train into subsets: X_train1, X_test1, y_train1, y_test1
+    - Scaled X_train1, X_test1 Using StandardScaler
+    - The target data is imbalanced, True 15%; False 85%.
+    - Create a new feature of 'total charge' that is the sum of all the charges.
+2. Modeling:
+    - We selected StackingClassifier as our algorithm.
+       - Model stacking is also called meta-stacking, where multiple models are stacked, and their predictions are aggregated. In this case, more models are better because the more likely they have the potential to pick up different characteristics of the data.
+    - We created two functions:
+       - `metrics`: it is a function to generate accuracy, precision, recall, and f-1 scores.
+       - `make_model`: it is a function that generate the results from StackingClassifier with four parameters: X_train, X_test, y_train, y_test.
+          - Estimators (submodels) selection: We selected K-Nearest-Neighbors(KNN), RandomForest, LogisticRegression, and GradientBoosting as submodels first, but the results showed that KNN generates had very poor performance on prediction with low scores on accuracy, precision, recall, and f-1. Therefore, we removed KNN from the estimators of the StackingClassifier algorithm. We used logistic Regression model as the final model which is the default as well.
+    - Model results: we got relatively good model performance using Stacking.
+    - Model improvement:
+       - The specific goal is to improve the model performance of correctly predicting a customer will stop doing business, which is the TRUE value in the target data. More specifically, we want our model predicts correctly when it is true, and reduce false negative, which means it is predicted false while it is actually true.
+       - Therefore, we want a high recall score. Our initial recall score is around 0.75.
+    - Feature selections/engineering: In order to increase the recall score, we tried to remove some features that have small values on feature importances. When removing dummyed 'state' variable, the recall score increases. Removing the other features resulted in decreasing the recall scores. Therefore, we keeps all features but 'state'.
+3. Model evaluation: We generated the confusion matrix and applied the function named 'metrics' to generate accuracy, precision, recall, and f-1 scores.
+    - Final model: StackingClassifier with the following parameters:
+      ```
+      estimators = [
+        ('rf', RandomForestClassifier()),
+        ('log', LogisticRegression(solver = 'liblinear')),
+        ('grad', GradientBoostingClassifier())
+      ], final_estimator = 'LogisticRegression()',
+      cv = 5
+      ```
+    - Model evaluation: Accuracy: 0.98; Precision: 1.0;  Recall: 0.89;  F1: 0.94
+4. Pickle: we created a pickle file named model.pickle. Using pickle, we can call the model without re-training.

--- a/reports/Memo.md
+++ b/reports/Memo.md
@@ -1,53 +1,57 @@
-## Customer Chur Classification Project Memo
+# Customer Churn Classification Project Memo
 
-Title: 
+## Title:
 
-    Predicting Customer Churn in SyrialTel Company using StackingClassifier Algorithm
+Predicting Customer Churn in SyriaTel Company using StackingClassifier Algorithm
 
-Business problem: 
+## Business problem:
 
-    SyrialTel company is losing money on customers who stop doing business with them after a shortwhile of service. For example, customer singed for a promotion as a new user, but churn after the promotion is over. By predicitng if a customer will churn or not, SyrialTel could allocate more resources on the ones that will keep doing business with the company. 
+SyriaTel company is losing money on customers who stop doing business with them after a short while of service. For example, a customer signed for a promotion as a new user, but churned after the promotion is over. By predicting if a customer will churn or not, SyriaTel could allocate more resources on the ones that will keep doing business with the company.
 
-Objective: 
+## Objective:
 
-    This project is aimed to build a sophisticated machine learning algorithm that help SyrialTel company successfully predict if a customer will soon stop doing business with the company based on historical data. So that the company will not lose money on these who will not do business with the company soon. 
+This project is aimed to build a sophisticated machine learning algorithm that helps SyriaTel company successfully predict if a customer will soon stop doing business with the company based on historical data. So that the company will not lose money on these who will not do business with the company soon.
     
-Methods and Model Selection:
+## Methods and Model Selection:
 
-    In order to optimizing the classification between customers who will soon stop doing business with SyrialTel and who will keep doing business, we selecetd StackingClassifier algorithm, where multiple models are stacked, and their predictions are aggregated. In this case, more models are better because the more likely they have the potential to pick up different characteristics of the data.
+In order to optimize the classification between customers who will soon stop doing business with SyriaTel and who will keep doing business, we selected StackingClassifier algorithm, where multiple models are stacked, and their predictions are aggregated. In this case, more models are better because the more likely they have the potential to pick up different characteristics of the data.
     
-    We initially stacked K-nearest-neighbors, randorm forest, logistic regression, and gradient boosting as submodels or estimators. KNN was removed because of its poor performance based on our evaluation metrics: accuracy, precision, recall, and f-1 scores. 
+We initially stacked K-nearest-neighbors, random forest, logistic regression, and gradient boosting as submodels or estimators. KNN was removed because of its poor performance based on our evaluation metrics: accuracy, precision, recall, and f-1 scores.
 
-Final model: 
+## Final model:
 
-          StackingClassifier with estimators = [('rf', RandomForestClassifier()),
-                                                ('log', LogisticRegression(solver = 'liblinear')),                                                     
-                                                ('grad', GradientBoostingClassifier())] , 
-                             final_estimator = 'LogisticRegression()',
-                                          cv = 5
-          Model evaluation: Accuracy: 0.98; Precision: 1.0;  Recall: 0.89;  F1: 0.94. 
-          We have a relatively low recall and high precision, which means the model can’t detect the class perfectly but is highly trustable when it 
-          does. 
+StackingClassifier with parameters
 
+```
+estimators = [
+    ('rf', RandomForestClassifier()),
+    ('log', LogisticRegression(solver = 'liblinear'),
+    ('grad', GradientBoostingClassifier())
+],
+final_estimator = 'LogisticRegression()',
+cv = 5
+```
 
-Business implication:
+### Model evaluation:
 
-    Our model has a relatively high performance according to the evaluation metrics which include accuracy, precision, recall, and F-1 score. We are confident to implement our model in the business. A caution is that the recall score is 0.773, which means the model has 23% chance to misclassify these who would stop doing business with SyriaTel as will continue doing business. 
+Accuracy: 0.98; Precision: 1.0;  Recall: 0.89;  F1: 0.94.
 
+We have a relatively low recall and high precision, which means the model can’t detect the class perfectly but is highly trustable when it does.
 
-Limitations of the model: 
+## Business implication:
 
-    The target variable in the dataset is inbalanced. There are only 15% of target variable are True, and 85% are False. The purpose of the modeling is to correctly detect the customers who with a True value, and reduce the chance when it fails to detect the True values, which means when it is positive, but was calssfied as negative, the false negative. Therefore, we want a high recall score in our model.
+Our model has a relatively high performance according to the evaluation metrics which include accuracy, precision, recall, and F-1 score. We are confident to implement our model in the business. A caution is that the recall score is 0.773, which means the model has 23% chance to misclassify these who would stop doing business with SyriaTel as will continue doing business.
 
-    With a few feature engineering and selections, we have the final model with a recall as 0.89. It is satisfactory, but not ideal. We want to inform this score to the leadership team of the company that, we have 11% chance missclassifying the customers who will stop doing business as customers who would continue doing the business with the comany. 
+## Limitations of the model:
 
+The target variable in the dataset is imbalanced. There are only 15% of target variable are True, and 85% are False. The purpose of the modeling is to correctly detect the customers who with a True value, and reduce the chance when it fails to detect the True values, which means when it is positive, but was classified as negative, the false negative. Therefore, we want a high recall score in our model.
 
-Unexpected results during the experiments:
+With a few feature engineering and selections, we have the final model with a recall as 0.89. It is satisfactory, but not ideal. We want to inform this score to the leadership team of the company that, we have 11% chance misclassifying the customers who will stop doing business as customers who would continue doing the business with the company.
 
-    Unexpected signs of coefficients, after we dummuy code the state, the model performance decreased on the test dataset. This might because a categorical predictor variable can have only a small number of observations having a certain value. In a classification problem, these few observations by chance may have the same response value. Such “perfect” predictors may cause overfitting, especially when tree-based models are used. One conservative approach is to remove all dummy variables corresponding to rare categories. A cutoff of 10 observations is recommended (Luo,& e.t, 2016). Based on this recommendation and the difference of model performance, we removed the feature of 'state'
+## Unexpected results during the experiments:
 
+Unexpected signs of coefficients, after we dummy code the state, the model performance decreased on the test dataset. This might because a categorical predictor variable can have only a small number of observations having a certain value. In a classification problem, these few observations by chance may have the same response value. Such “perfect” predictors may cause overfitting, especially when tree-based models are used. One conservative approach is to remove all dummy variables corresponding to rare categories. A cutoff of 10 observations is recommended (Luo,& e.t, 2016). Based on this recommendation and the difference of model performance, we removed the feature of 'state'
 
-
-References:
+## References:
 
 Luo, W., Phung, D., Tran, T., Gupta, S., Rana, S., Karmakar, C., Shilton, A., Yearwood, J., Dimitrova, N., Ho, T. B., Venkatesh, S., & Berk, M. (2016). Guidelines for Developing and Reporting Machine Learning Predictive Models in Biomedical Research: A Multidisciplinary View. Journal of medical Internet research, 18(12), e323. https://doi.org/10.2196/jmir.5870


### PR DESCRIPTION
Both the README and memo were written like raw text files, not making use of Markdown formatting.  This PR:
 - Adds headings
 - Adjusts indentation so text is not rendered as raw
 - Adjusts outline format to be compatible with markdown (my best guess of indentation levels intended)

This PR also includes various spelling and grammar fixes